### PR TITLE
Add time zone info to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:14-alpine
 
+RUN apk add tzdata && \
+    cp /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    echo "America/New_York" > /etc/timezone && \
+    apk del tzdata
+
 WORKDIR /usr/src/app
 
 COPY package*.json ./


### PR DESCRIPTION
Fixes an issue we saw where the bot refused to run !join during mentoring hours.